### PR TITLE
Add customizable variable flymake-credo-min-priority

### DIFF
--- a/flymake-credo.el
+++ b/flymake-credo.el
@@ -47,11 +47,11 @@
 
 (defcustom flymake-credo-strict t
   "Use credo in a strict mode or not."
-  :group 'fymake-credo
+  :group 'flymake-credo
   :type 'boolean)
 
 (defcustom flymake-credo-min-priority 0
-  "Min priority of error to display."
+  "Minimum priority of credo warning to be reported by flymake."
   :group 'flymake-credo
   :type 'integer)
 
@@ -84,7 +84,8 @@ Check for problems, then call REPORT-FN with results."
          (default-directory (if project
                                 (expand-file-name (project-root project))
                               default-directory))
-         (source (current-buffer)))
+         (source (current-buffer))
+         (min-priority (number-to-string flymake-credo-min-priority)))
     (save-restriction
       (widen)
 
@@ -100,7 +101,7 @@ Check for problems, then call REPORT-FN with results."
                         "--format"
                         "json"
                         "--min-priority"
-                        ,flymake-credo-min-priority
+                        ,min-priority
                         "--read-from-stdin")
              :sentinel
              (lambda (proc _event)

--- a/flymake-credo.el
+++ b/flymake-credo.el
@@ -50,6 +50,11 @@
   :group 'fymake-credo
   :type 'boolean)
 
+(defcustom flymake-credo-min-priority 0
+  "Min priority of error to display."
+  :group 'flymake-credo
+  :type 'integer)
+
 (defvar-local flymake-credo--proc nil)
 
 (defvar-local flymake-credo--command nil)
@@ -92,7 +97,10 @@ Check for problems, then call REPORT-FN with results."
              :command `(,@flymake-credo--command
                         "list"
                         ,(if flymake-credo-strict "--strict" "")
-                        "--format=json"
+                        "--format"
+                        "json"
+                        "--min-priority"
+                        ,flymake-credo-min-priority
                         "--read-from-stdin")
              :sentinel
              (lambda (proc _event)


### PR DESCRIPTION
Hello,

I'd like to add a small customizable variable to this package so that we can mute some lower priority warnings coming from credo.
I propose `flymake-credo-min-priority`. This variable controls the minimum level of priority to display in the flymake diagnostics

In addition I made a small fix to the group of `flymake-credo-strict`